### PR TITLE
Add per-item size restriction for menu items

### DIFF
--- a/src/components/admin/fmb/create-menu/create-menu.tsx
+++ b/src/components/admin/fmb/create-menu/create-menu.tsx
@@ -74,6 +74,8 @@ const CreateMenu = ({ setPage, refetchMenus }: any) => {
       item.date = item.date.format("MM-DD-YYYY")
       item.nothaali = item.nothaali || false
       item.reasonNoThaali = item.reasonNoThaali || null
+      item.sizeRestrictionEnabled = item.sizeRestrictionEnabled || false
+      item.maxSize = item.sizeRestrictionEnabled ? item.maxSize : null
       item.id = generateUniqueIDForItem()
     }
     return newMenuItemsArr

--- a/src/components/admin/fmb/create-menu/menu-items-form.tsx
+++ b/src/components/admin/fmb/create-menu/menu-items-form.tsx
@@ -330,67 +330,67 @@ const MenuItemsForm = ({
                         <Input placeholder="Reason for no thaali (optional)" />
                       </Form.Item>
                     )}
-                    <Row>
-                      <Col xs={12} sm={8}>
-                        <div style={{ display: "flex", alignItems: "center", gap: ".4rem" }}>
-                          <Form.Item
-                            name={[field.name, "nothaali"]}
-                            fieldKey={[field.fieldKey, "nothaali"] as any}
-                            valuePropName="checked"
-                            style={{ marginBottom: 0 }}
+                    <Row style={{ alignItems: "center" }}>
+                      <Col xs={4} sm={3}>
+                        <Form.Item
+                          name={[field.name, "nothaali"]}
+                          fieldKey={[field.fieldKey, "nothaali"] as any}
+                          valuePropName="checked"
+                          style={{ marginBottom: 0 }}
+                        >
+                          <Checkbox
+                            onChange={(event: any) =>
+                              handleCheckBox(event, field.name)
+                            }
                           >
-                            <Checkbox
-                              onChange={(event: any) =>
-                                handleCheckBox(event, field.name)
-                              }
-                            >
-                              No Thaali
-                            </Checkbox>
-                          </Form.Item>
-
-                          {!disabledItems.includes(field.name) && (
-                            <Form.Item
-                              noStyle
-                              shouldUpdate={(prev: any, curr: any) =>
-                                prev?.items?.[field.name]?.sizeRestrictionEnabled !==
-                                curr?.items?.[field.name]?.sizeRestrictionEnabled
-                              }
-                            >
-                              {() => (
-                                <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+                            No Thaali
+                          </Checkbox>
+                        </Form.Item>
+                      </Col>
+                      <Col xs={4} sm={5}>
+                        {!disabledItems.includes(field.name) && (
+                          <Form.Item
+                            noStyle
+                            shouldUpdate={(prev: any, curr: any) =>
+                              prev?.items?.[field.name]?.sizeRestrictionEnabled !==
+                              curr?.items?.[field.name]?.sizeRestrictionEnabled
+                            }
+                          >
+                            {() => (
+                              <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+                                <Form.Item
+                                  name={[field.name, "sizeRestrictionEnabled"]}
+                                  fieldKey={[field.fieldKey, "sizeRestrictionEnabled"] as any}
+                                  valuePropName="checked"
+                                  style={{ marginBottom: 0 }}
+                                >
+                                  <Switch size="small" />
+                                </Form.Item>
+                                <span style={{ fontSize: ".85rem", color: "#666", whiteSpace: "nowrap" }}>
+                                  Limit
+                                </span>
+                                {menuItemsForm.getFieldValue(["items", field.name, "sizeRestrictionEnabled"]) && (
                                   <Form.Item
-                                    name={[field.name, "sizeRestrictionEnabled"]}
-                                    fieldKey={[field.fieldKey, "sizeRestrictionEnabled"] as any}
-                                    valuePropName="checked"
+                                    name={[field.name, "maxSize"]}
+                                    fieldKey={[field.fieldKey, "maxSize"] as any}
+                                    rules={[{ required: true, message: "Required" }]}
                                     style={{ marginBottom: 0 }}
                                   >
-                                    <Switch size="small" />
+                                    <Select size="small" style={{ width: 90 }} placeholder="Max">
+                                      {ALL_SIZES.map((size) => (
+                                        <Select.Option key={size} value={size}>
+                                          {size}
+                                        </Select.Option>
+                                      ))}
+                                    </Select>
                                   </Form.Item>
-                                  {menuItemsForm.getFieldValue(["items", field.name, "sizeRestrictionEnabled"]) ? (
-                                    <Form.Item
-                                      name={[field.name, "maxSize"]}
-                                      fieldKey={[field.fieldKey, "maxSize"] as any}
-                                      rules={[{ required: true, message: "Required" }]}
-                                      style={{ marginBottom: 0 }}
-                                    >
-                                      <Select size="small" style={{ width: 82 }} placeholder="Max">
-                                        {ALL_SIZES.map((size) => (
-                                          <Select.Option key={size} value={size}>
-                                            {size}
-                                          </Select.Option>
-                                        ))}
-                                      </Select>
-                                    </Form.Item>
-                                  ) : (
-                                    <span style={{ fontSize: ".8rem", color: "#999" }}>Limit</span>
-                                  )}
-                                </div>
-                              )}
-                            </Form.Item>
-                          )}
-                        </div>
+                                )}
+                              </div>
+                            )}
+                          </Form.Item>
+                        )}
                       </Col>
-                      <Col xs={12} sm={4}>
+                      <Col xs={4} sm={4}>
                         <Button
                           className="float-right"
                           style={{ width: "100%" }}

--- a/src/components/admin/fmb/create-menu/menu-items-form.tsx
+++ b/src/components/admin/fmb/create-menu/menu-items-form.tsx
@@ -330,80 +330,75 @@ const MenuItemsForm = ({
                         <Input placeholder="Reason for no thaali (optional)" />
                       </Form.Item>
                     )}
-                    <Row style={{ alignItems: "center" }}>
-                      <Col xs={4} sm={3}>
-                        <Form.Item
-                          name={[field.name, "nothaali"]}
-                          fieldKey={[field.fieldKey, "nothaali"] as any}
-                          valuePropName="checked"
-                          style={{ marginBottom: 0 }}
+                    <div style={{ display: "flex", alignItems: "center" }}>
+                      <Form.Item
+                        name={[field.name, "nothaali"]}
+                        fieldKey={[field.fieldKey, "nothaali"] as any}
+                        valuePropName="checked"
+                        style={{ marginBottom: 0, marginRight: "1rem" }}
+                      >
+                        <Checkbox
+                          onChange={(event: any) =>
+                            handleCheckBox(event, field.name)
+                          }
                         >
-                          <Checkbox
-                            onChange={(event: any) =>
-                              handleCheckBox(event, field.name)
-                            }
-                          >
-                            No Thaali
-                          </Checkbox>
-                        </Form.Item>
-                      </Col>
-                      <Col xs={4} sm={5}>
-                        {!disabledItems.includes(field.name) && (
-                          <Form.Item
-                            noStyle
-                            shouldUpdate={(prev: any, curr: any) =>
-                              prev?.items?.[field.name]?.sizeRestrictionEnabled !==
-                              curr?.items?.[field.name]?.sizeRestrictionEnabled
-                            }
-                          >
-                            {() => (
-                              <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+                          No Thaali
+                        </Checkbox>
+                      </Form.Item>
+
+                      {!disabledItems.includes(field.name) && (
+                        <Form.Item
+                          noStyle
+                          shouldUpdate={(prev: any, curr: any) =>
+                            prev?.items?.[field.name]?.sizeRestrictionEnabled !==
+                            curr?.items?.[field.name]?.sizeRestrictionEnabled
+                          }
+                        >
+                          {() => (
+                            <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+                              <Form.Item
+                                name={[field.name, "sizeRestrictionEnabled"]}
+                                fieldKey={[field.fieldKey, "sizeRestrictionEnabled"] as any}
+                                valuePropName="checked"
+                                style={{ marginBottom: 0 }}
+                              >
+                                <Switch size="small" />
+                              </Form.Item>
+                              <span style={{ fontSize: ".85rem", color: "#666", whiteSpace: "nowrap" }}>
+                                Limit size
+                              </span>
+                              {menuItemsForm.getFieldValue(["items", field.name, "sizeRestrictionEnabled"]) && (
                                 <Form.Item
-                                  name={[field.name, "sizeRestrictionEnabled"]}
-                                  fieldKey={[field.fieldKey, "sizeRestrictionEnabled"] as any}
-                                  valuePropName="checked"
+                                  name={[field.name, "maxSize"]}
+                                  fieldKey={[field.fieldKey, "maxSize"] as any}
+                                  rules={[{ required: true, message: "Required" }]}
                                   style={{ marginBottom: 0 }}
                                 >
-                                  <Switch size="small" />
+                                  <Select size="small" style={{ width: 90 }} placeholder="Max">
+                                    {ALL_SIZES.map((size) => (
+                                      <Select.Option key={size} value={size}>
+                                        {size}
+                                      </Select.Option>
+                                    ))}
+                                  </Select>
                                 </Form.Item>
-                                <span style={{ fontSize: ".85rem", color: "#666", whiteSpace: "nowrap" }}>
-                                  Limit
-                                </span>
-                                {menuItemsForm.getFieldValue(["items", field.name, "sizeRestrictionEnabled"]) && (
-                                  <Form.Item
-                                    name={[field.name, "maxSize"]}
-                                    fieldKey={[field.fieldKey, "maxSize"] as any}
-                                    rules={[{ required: true, message: "Required" }]}
-                                    style={{ marginBottom: 0 }}
-                                  >
-                                    <Select size="small" style={{ width: 90 }} placeholder="Max">
-                                      {ALL_SIZES.map((size) => (
-                                        <Select.Option key={size} value={size}>
-                                          {size}
-                                        </Select.Option>
-                                      ))}
-                                    </Select>
-                                  </Form.Item>
-                                )}
-                              </div>
-                            )}
-                          </Form.Item>
-                        )}
-                      </Col>
-                      <Col xs={4} sm={4}>
-                        <Button
-                          className="float-right"
-                          style={{ width: "100%" }}
-                          danger
-                          onClick={async () => {
-                            await remove(field.name)
-                            await resetDisabledItemsArrayAfterItemDelete()
-                          }}
-                        >
-                          Delete
-                        </Button>
-                      </Col>
-                    </Row>
+                              )}
+                            </div>
+                          )}
+                        </Form.Item>
+                      )}
+
+                      <Button
+                        style={{ marginLeft: "auto" }}
+                        danger
+                        onClick={async () => {
+                          await remove(field.name)
+                          await resetDisabledItemsArrayAfterItemDelete()
+                        }}
+                      >
+                        Delete
+                      </Button>
+                    </div>
                     <Divider
                       style={{ marginBottom: ".8rem", marginTop: ".8rem" }}
                     />

--- a/src/components/admin/fmb/create-menu/menu-items-form.tsx
+++ b/src/components/admin/fmb/create-menu/menu-items-form.tsx
@@ -14,7 +14,10 @@ import {
   Upload,
   Alert,
   Popover,
+  Select,
+  Switch,
 } from "antd"
+import { ALL_SIZES } from "../../../../utils/thaali-sizes"
 import CustomMessage from "../../../custom-message"
 import Checklist from "./presubmit-checklist"
 import { Row, Col } from "react-bootstrap"
@@ -362,6 +365,50 @@ const MenuItemsForm = ({
                         </Button>
                       </Col>
                     </Row>
+
+                    {!disabledItems.includes(field.name) && (
+                      <Row style={{ marginTop: ".5rem" }}>
+                        <Col xs={12} sm={12}>
+                          <Form.Item
+                            noStyle
+                            shouldUpdate={(prev: any, curr: any) =>
+                              prev?.items?.[field.name]?.sizeRestrictionEnabled !==
+                              curr?.items?.[field.name]?.sizeRestrictionEnabled
+                            }
+                          >
+                            {() => (
+                              <Space>
+                                <Form.Item
+                                  name={[field.name, "sizeRestrictionEnabled"]}
+                                  fieldKey={[field.fieldKey, "sizeRestrictionEnabled"] as any}
+                                  valuePropName="checked"
+                                  style={{ marginBottom: "0rem" }}
+                                >
+                                  <Switch size="small" />
+                                </Form.Item>
+                                <span>Limit item size</span>
+                                {menuItemsForm.getFieldValue(["items", field.name, "sizeRestrictionEnabled"]) && (
+                                  <Form.Item
+                                    name={[field.name, "maxSize"]}
+                                    fieldKey={[field.fieldKey, "maxSize"] as any}
+                                    rules={[{ required: true, message: "Select max size" }]}
+                                    style={{ marginBottom: "0rem" }}
+                                  >
+                                    <Select style={{ width: 120 }} placeholder="Max size">
+                                      {ALL_SIZES.map((size) => (
+                                        <Select.Option key={size} value={size}>
+                                          {size}
+                                        </Select.Option>
+                                      ))}
+                                    </Select>
+                                  </Form.Item>
+                                )}
+                              </Space>
+                            )}
+                          </Form.Item>
+                        </Col>
+                      </Row>
+                    )}
                     <Divider
                       style={{ marginBottom: ".8rem", marginTop: ".8rem" }}
                     />

--- a/src/components/admin/fmb/create-menu/menu-items-form.tsx
+++ b/src/components/admin/fmb/create-menu/menu-items-form.tsx
@@ -330,85 +330,75 @@ const MenuItemsForm = ({
                         <Input placeholder="Reason for no thaali (optional)" />
                       </Form.Item>
                     )}
-                    <Row>
-                      <Col xs={7} sm={8}>
-                        <Form.Item
-                          name={[field.name, "nothaali"]}
-                          fieldKey={[field.fieldKey, "nothaali"] as any}
-                          valuePropName="checked"
-                          style={{ marginBottom: "0rem" }}
+                    <div style={{ display: "flex", alignItems: "center", flexWrap: "wrap", gap: ".5rem" }}>
+                      <Form.Item
+                        name={[field.name, "nothaali"]}
+                        fieldKey={[field.fieldKey, "nothaali"] as any}
+                        valuePropName="checked"
+                        style={{ marginBottom: 0 }}
+                      >
+                        <Checkbox
+                          onChange={(event: any) =>
+                            handleCheckBox(event, field.name)
+                          }
                         >
-                          <Checkbox
-                            onChange={(event: any) =>
-                              handleCheckBox(event, field.name)
-                            }
-                          >
-                            No Thaali
-                          </Checkbox>
+                          No Thaali
+                        </Checkbox>
+                      </Form.Item>
+
+                      {!disabledItems.includes(field.name) && (
+                        <Form.Item
+                          noStyle
+                          shouldUpdate={(prev: any, curr: any) =>
+                            prev?.items?.[field.name]?.sizeRestrictionEnabled !==
+                            curr?.items?.[field.name]?.sizeRestrictionEnabled
+                          }
+                        >
+                          {() => (
+                            <Space size={4} style={{ alignItems: "center" }}>
+                              <Form.Item
+                                name={[field.name, "sizeRestrictionEnabled"]}
+                                fieldKey={[field.fieldKey, "sizeRestrictionEnabled"] as any}
+                                valuePropName="checked"
+                                style={{ marginBottom: 0 }}
+                              >
+                                <Switch size="small" />
+                              </Form.Item>
+                              <span style={{ fontSize: ".85rem", color: "#666" }}>Max size</span>
+                              {menuItemsForm.getFieldValue(["items", field.name, "sizeRestrictionEnabled"]) && (
+                                <Form.Item
+                                  name={[field.name, "maxSize"]}
+                                  fieldKey={[field.fieldKey, "maxSize"] as any}
+                                  rules={[{ required: true, message: "Select max size" }]}
+                                  style={{ marginBottom: 0 }}
+                                >
+                                  <Select size="small" style={{ width: 90 }} placeholder="Max">
+                                    {ALL_SIZES.map((size) => (
+                                      <Select.Option key={size} value={size}>
+                                        {size}
+                                      </Select.Option>
+                                    ))}
+                                  </Select>
+                                </Form.Item>
+                              )}
+                            </Space>
+                          )}
                         </Form.Item>
-                      </Col>
-                      <Col xs={5} sm={4}>
+                      )}
+
+                      <div style={{ marginLeft: "auto" }}>
                         <Button
-                          className="float-right"
-                          style={{ width: "100%" }}
+                          style={{ minWidth: "70px" }}
                           danger
                           onClick={async () => {
-                            // reset disabled items array after removing an item
-                            // using the fields value after removal to determine which indexes are still disabled
                             await remove(field.name)
-
-                            //reset the disabled items array
                             await resetDisabledItemsArrayAfterItemDelete()
                           }}
                         >
                           Delete
                         </Button>
-                      </Col>
-                    </Row>
-
-                    {!disabledItems.includes(field.name) && (
-                      <Row style={{ marginTop: ".5rem" }}>
-                        <Col xs={12} sm={12}>
-                          <Form.Item
-                            noStyle
-                            shouldUpdate={(prev: any, curr: any) =>
-                              prev?.items?.[field.name]?.sizeRestrictionEnabled !==
-                              curr?.items?.[field.name]?.sizeRestrictionEnabled
-                            }
-                          >
-                            {() => (
-                              <Space>
-                                <Form.Item
-                                  name={[field.name, "sizeRestrictionEnabled"]}
-                                  fieldKey={[field.fieldKey, "sizeRestrictionEnabled"] as any}
-                                  valuePropName="checked"
-                                  style={{ marginBottom: "0rem" }}
-                                >
-                                  <Switch size="small" />
-                                </Form.Item>
-                                <span>Limit item size</span>
-                                {menuItemsForm.getFieldValue(["items", field.name, "sizeRestrictionEnabled"]) && (
-                                  <Form.Item
-                                    name={[field.name, "maxSize"]}
-                                    fieldKey={[field.fieldKey, "maxSize"] as any}
-                                    rules={[{ required: true, message: "Select max size" }]}
-                                    style={{ marginBottom: "0rem" }}
-                                  >
-                                    <Select style={{ width: 120 }} placeholder="Max size">
-                                      {ALL_SIZES.map((size) => (
-                                        <Select.Option key={size} value={size}>
-                                          {size}
-                                        </Select.Option>
-                                      ))}
-                                    </Select>
-                                  </Form.Item>
-                                )}
-                              </Space>
-                            )}
-                          </Form.Item>
-                        </Col>
-                      </Row>
-                    )}
+                      </div>
+                    </div>
                     <Divider
                       style={{ marginBottom: ".8rem", marginTop: ".8rem" }}
                     />

--- a/src/components/admin/fmb/create-menu/menu-items-form.tsx
+++ b/src/components/admin/fmb/create-menu/menu-items-form.tsx
@@ -376,7 +376,7 @@ const MenuItemsForm = ({
                                     style={{ marginBottom: 0 }}
                                   >
                                     <Select size="small" style={{ width: 90 }} placeholder="Max">
-                                      {ALL_SIZES.map((size) => (
+                                      {ALL_SIZES.filter((s) => s !== "Grand").map((size) => (
                                         <Select.Option key={size} value={size}>
                                           {size}
                                         </Select.Option>

--- a/src/components/admin/fmb/create-menu/menu-items-form.tsx
+++ b/src/components/admin/fmb/create-menu/menu-items-form.tsx
@@ -330,65 +330,70 @@ const MenuItemsForm = ({
                         <Input placeholder="Reason for no thaali (optional)" />
                       </Form.Item>
                     )}
-                    <div style={{ display: "flex", alignItems: "center", flexWrap: "wrap", gap: ".5rem" }}>
-                      <Form.Item
-                        name={[field.name, "nothaali"]}
-                        fieldKey={[field.fieldKey, "nothaali"] as any}
-                        valuePropName="checked"
-                        style={{ marginBottom: 0 }}
-                      >
-                        <Checkbox
-                          onChange={(event: any) =>
-                            handleCheckBox(event, field.name)
-                          }
-                        >
-                          No Thaali
-                        </Checkbox>
-                      </Form.Item>
+                    <Row>
+                      <Col xs={12} sm={8}>
+                        <div style={{ display: "flex", alignItems: "center", gap: ".4rem" }}>
+                          <Form.Item
+                            name={[field.name, "nothaali"]}
+                            fieldKey={[field.fieldKey, "nothaali"] as any}
+                            valuePropName="checked"
+                            style={{ marginBottom: 0 }}
+                          >
+                            <Checkbox
+                              onChange={(event: any) =>
+                                handleCheckBox(event, field.name)
+                              }
+                            >
+                              No Thaali
+                            </Checkbox>
+                          </Form.Item>
 
-                      {!disabledItems.includes(field.name) && (
-                        <Form.Item
-                          noStyle
-                          shouldUpdate={(prev: any, curr: any) =>
-                            prev?.items?.[field.name]?.sizeRestrictionEnabled !==
-                            curr?.items?.[field.name]?.sizeRestrictionEnabled
-                          }
-                        >
-                          {() => (
-                            <Space size={4} style={{ alignItems: "center" }}>
-                              <Form.Item
-                                name={[field.name, "sizeRestrictionEnabled"]}
-                                fieldKey={[field.fieldKey, "sizeRestrictionEnabled"] as any}
-                                valuePropName="checked"
-                                style={{ marginBottom: 0 }}
-                              >
-                                <Switch size="small" />
-                              </Form.Item>
-                              <span style={{ fontSize: ".85rem", color: "#666" }}>Max size</span>
-                              {menuItemsForm.getFieldValue(["items", field.name, "sizeRestrictionEnabled"]) && (
-                                <Form.Item
-                                  name={[field.name, "maxSize"]}
-                                  fieldKey={[field.fieldKey, "maxSize"] as any}
-                                  rules={[{ required: true, message: "Select max size" }]}
-                                  style={{ marginBottom: 0 }}
-                                >
-                                  <Select size="small" style={{ width: 90 }} placeholder="Max">
-                                    {ALL_SIZES.map((size) => (
-                                      <Select.Option key={size} value={size}>
-                                        {size}
-                                      </Select.Option>
-                                    ))}
-                                  </Select>
-                                </Form.Item>
+                          {!disabledItems.includes(field.name) && (
+                            <Form.Item
+                              noStyle
+                              shouldUpdate={(prev: any, curr: any) =>
+                                prev?.items?.[field.name]?.sizeRestrictionEnabled !==
+                                curr?.items?.[field.name]?.sizeRestrictionEnabled
+                              }
+                            >
+                              {() => (
+                                <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+                                  <Form.Item
+                                    name={[field.name, "sizeRestrictionEnabled"]}
+                                    fieldKey={[field.fieldKey, "sizeRestrictionEnabled"] as any}
+                                    valuePropName="checked"
+                                    style={{ marginBottom: 0 }}
+                                  >
+                                    <Switch size="small" />
+                                  </Form.Item>
+                                  {menuItemsForm.getFieldValue(["items", field.name, "sizeRestrictionEnabled"]) ? (
+                                    <Form.Item
+                                      name={[field.name, "maxSize"]}
+                                      fieldKey={[field.fieldKey, "maxSize"] as any}
+                                      rules={[{ required: true, message: "Required" }]}
+                                      style={{ marginBottom: 0 }}
+                                    >
+                                      <Select size="small" style={{ width: 82 }} placeholder="Max">
+                                        {ALL_SIZES.map((size) => (
+                                          <Select.Option key={size} value={size}>
+                                            {size}
+                                          </Select.Option>
+                                        ))}
+                                      </Select>
+                                    </Form.Item>
+                                  ) : (
+                                    <span style={{ fontSize: ".8rem", color: "#999" }}>Limit</span>
+                                  )}
+                                </div>
                               )}
-                            </Space>
+                            </Form.Item>
                           )}
-                        </Form.Item>
-                      )}
-
-                      <div style={{ marginLeft: "auto" }}>
+                        </div>
+                      </Col>
+                      <Col xs={12} sm={4}>
                         <Button
-                          style={{ minWidth: "70px" }}
+                          className="float-right"
+                          style={{ width: "100%" }}
                           danger
                           onClick={async () => {
                             await remove(field.name)
@@ -397,8 +402,8 @@ const MenuItemsForm = ({
                         >
                           Delete
                         </Button>
-                      </div>
-                    </div>
+                      </Col>
+                    </Row>
                     <Divider
                       style={{ marginBottom: ".8rem", marginTop: ".8rem" }}
                     />

--- a/src/components/admin/fmb/create-menu/menu-items-form.tsx
+++ b/src/components/admin/fmb/create-menu/menu-items-form.tsx
@@ -330,66 +330,68 @@ const MenuItemsForm = ({
                         <Input placeholder="Reason for no thaali (optional)" />
                       </Form.Item>
                     )}
-                    <div style={{ display: "flex", alignItems: "center" }}>
-                      <Form.Item
-                        name={[field.name, "nothaali"]}
-                        fieldKey={[field.fieldKey, "nothaali"] as any}
-                        valuePropName="checked"
-                        style={{ marginBottom: 0, marginRight: "1rem" }}
-                      >
-                        <Checkbox
-                          onChange={(event: any) =>
-                            handleCheckBox(event, field.name)
-                          }
-                        >
-                          No Thaali
-                        </Checkbox>
-                      </Form.Item>
-
-                      {!disabledItems.includes(field.name) && (
+                    <div style={{ display: "flex", alignItems: "center", flexWrap: "wrap", gap: ".5rem 1rem" }}>
+                      <div style={{ display: "flex", alignItems: "center", flex: "1 1 auto", minWidth: 0 }}>
                         <Form.Item
-                          noStyle
-                          shouldUpdate={(prev: any, curr: any) =>
-                            prev?.items?.[field.name]?.sizeRestrictionEnabled !==
-                            curr?.items?.[field.name]?.sizeRestrictionEnabled
-                          }
+                          name={[field.name, "nothaali"]}
+                          fieldKey={[field.fieldKey, "nothaali"] as any}
+                          valuePropName="checked"
+                          style={{ marginBottom: 0, marginRight: "1rem" }}
                         >
-                          {() => (
-                            <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
-                              <Form.Item
-                                name={[field.name, "sizeRestrictionEnabled"]}
-                                fieldKey={[field.fieldKey, "sizeRestrictionEnabled"] as any}
-                                valuePropName="checked"
-                                style={{ marginBottom: 0 }}
-                              >
-                                <Switch size="small" />
-                              </Form.Item>
-                              <span style={{ fontSize: ".85rem", color: "#666", whiteSpace: "nowrap" }}>
-                                Limit size
-                              </span>
-                              {menuItemsForm.getFieldValue(["items", field.name, "sizeRestrictionEnabled"]) && (
+                          <Checkbox
+                            onChange={(event: any) =>
+                              handleCheckBox(event, field.name)
+                            }
+                          >
+                            No Thaali
+                          </Checkbox>
+                        </Form.Item>
+
+                        {!disabledItems.includes(field.name) && (
+                          <Form.Item
+                            noStyle
+                            shouldUpdate={(prev: any, curr: any) =>
+                              prev?.items?.[field.name]?.sizeRestrictionEnabled !==
+                              curr?.items?.[field.name]?.sizeRestrictionEnabled
+                            }
+                          >
+                            {() => (
+                              <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
                                 <Form.Item
-                                  name={[field.name, "maxSize"]}
-                                  fieldKey={[field.fieldKey, "maxSize"] as any}
-                                  rules={[{ required: true, message: "Required" }]}
+                                  name={[field.name, "sizeRestrictionEnabled"]}
+                                  fieldKey={[field.fieldKey, "sizeRestrictionEnabled"] as any}
+                                  valuePropName="checked"
                                   style={{ marginBottom: 0 }}
                                 >
-                                  <Select size="small" style={{ width: 90 }} placeholder="Max">
-                                    {ALL_SIZES.map((size) => (
-                                      <Select.Option key={size} value={size}>
-                                        {size}
-                                      </Select.Option>
-                                    ))}
-                                  </Select>
+                                  <Switch size="small" />
                                 </Form.Item>
-                              )}
-                            </div>
-                          )}
-                        </Form.Item>
-                      )}
+                                <span style={{ fontSize: ".85rem", color: "#666", whiteSpace: "nowrap" }}>
+                                  Limit size
+                                </span>
+                                {menuItemsForm.getFieldValue(["items", field.name, "sizeRestrictionEnabled"]) && (
+                                  <Form.Item
+                                    name={[field.name, "maxSize"]}
+                                    fieldKey={[field.fieldKey, "maxSize"] as any}
+                                    rules={[{ required: true, message: "Required" }]}
+                                    style={{ marginBottom: 0 }}
+                                  >
+                                    <Select size="small" style={{ width: 90 }} placeholder="Max">
+                                      {ALL_SIZES.map((size) => (
+                                        <Select.Option key={size} value={size}>
+                                          {size}
+                                        </Select.Option>
+                                      ))}
+                                    </Select>
+                                  </Form.Item>
+                                )}
+                              </div>
+                            )}
+                          </Form.Item>
+                        )}
+                      </div>
 
                       <Button
-                        style={{ marginLeft: "auto" }}
+                        className="item-delete-btn"
                         danger
                         onClick={async () => {
                           await remove(field.name)
@@ -453,6 +455,12 @@ const MenuItemsWrapper = styled.div`
 
   div > .ant-space {
     width: 100%;
+  }
+
+  @media (max-width: 575px) {
+    .item-delete-btn {
+      width: 100%;
+    }
   }
 `
 

--- a/src/components/admin/fmb/create-menu/review-menu.tsx
+++ b/src/components/admin/fmb/create-menu/review-menu.tsx
@@ -42,6 +42,9 @@ const ReviewMenu = ({ setStep, hijrimonthForm, menuitemsForm, submitMenu }: any)
                   </li>
                 )}
                 <li>Date: {item.date.format("dddd, MMM Do YYYY")}</li>
+                {!item.nothaali && item.sizeRestrictionEnabled && (
+                  <li>Max Size: {item.maxSize}</li>
+                )}
               </ul>
             </div>
           )

--- a/src/components/admin/fmb/make-selections/make-selections.tsx
+++ b/src/components/admin/fmb/make-selections/make-selections.tsx
@@ -11,7 +11,7 @@ import {
   Checkbox,
   message,
 } from "antd"
-import { InfoCircleOutlined } from "@ant-design/icons"
+import { InfoCircleOutlined, WarningOutlined } from "@ant-design/icons"
 import styled from "styled-components"
 import { db } from "../../../../lib/firebase"
 import { doc, getDoc, getDocs, setDoc, updateDoc, collection, serverTimestamp, arrayUnion } from "firebase/firestore"
@@ -238,7 +238,7 @@ const MakeSelections = () => {
         if (!item.nothaali) {
           const allowed = getItemAllowedSizes(item)
           // Auto-clamp to item's effective max if selected size exceeds it
-          const effectiveSize = allowed.includes(size) ? size : allowed[allowed.length - 1]
+          const effectiveSize = allowed.includes(size) ? size : allowed[0]
           newSelections[item.id] = effectiveSize
           fieldUpdates[`selection_${item.id}`] = effectiveSize
         }
@@ -554,6 +554,14 @@ const MakeSelections = () => {
                           "dddd, MMM Do YYYY"
                         )}
                       </div>
+                      {item.sizeRestrictionEnabled && selections[item.id] &&
+                        selections[item.id] !== "No Thaali" &&
+                        !getItemAllowedSizes(item).includes(selections[item.id]) && (
+                        <div style={{ color: "#ff4d4f", fontSize: "0.85rem", marginTop: "0.25rem" }}>
+                          <WarningOutlined style={{ marginRight: "0.3rem" }} />
+                          Submitted "{selections[item.id]}" exceeds max ({item.maxSize})
+                        </div>
+                      )}
                     </Col>
                     <Col xs={24} md={12}>
                       <Form.Item

--- a/src/components/admin/fmb/make-selections/make-selections.tsx
+++ b/src/components/admin/fmb/make-selections/make-selections.tsx
@@ -19,6 +19,7 @@ import { DateContext } from "../../../../provider/date-context"
 import { AuthContext } from "../../../../provider/auth-context"
 import { shortMonthToLongMonth } from "../../../../functions/calendar"
 import CustomMessage from "../../../custom-message"
+import { getEffectiveMaxSize, getAllowedSizes } from "../../../../utils/thaali-sizes"
 import moment from "moment"
 
 const { Option } = Select
@@ -216,6 +217,17 @@ const MakeSelections = () => {
     }))
   }
 
+  const getItemEffectiveMaxSize = (item: any) => {
+    if (!selectedFamily) return "Grand"
+    const familyMax = selectedFamily.fmb.thaaliSize
+    const itemMax = item.sizeRestrictionEnabled ? item.maxSize : undefined
+    return getEffectiveMaxSize(familyMax, itemMax)
+  }
+
+  const getItemAllowedSizes = (item: any) => {
+    return getAllowedSizes(getItemEffectiveMaxSize(item))
+  }
+
   const handleUniversalChange = (checked: any, size: any) => {
     if (checked && size) {
       setUniversalSize(size)
@@ -224,8 +236,11 @@ const MakeSelections = () => {
 
       menuItems.forEach((item: any) => {
         if (!item.nothaali) {
-          newSelections[item.id] = size
-          fieldUpdates[`selection_${item.id}`] = size
+          const allowed = getItemAllowedSizes(item)
+          // Auto-clamp to item's effective max if selected size exceeds it
+          const effectiveSize = allowed.includes(size) ? size : allowed[allowed.length - 1]
+          newSelections[item.id] = effectiveSize
+          fieldUpdates[`selection_${item.id}`] = effectiveSize
         }
       })
 
@@ -528,6 +543,11 @@ const MakeSelections = () => {
                     <Col xs={24} md={12}>
                       <div style={{ fontSize: "1.1rem", fontWeight: "bold" }}>
                         {item.name}
+                        {item.sizeRestrictionEnabled && (
+                          <span style={{ fontSize: "0.8rem", color: "#faad14", marginLeft: "0.5rem" }}>
+                            (Max: {item.maxSize})
+                          </span>
+                        )}
                       </div>
                       <div style={{ color: "gray", fontSize: "0.9rem" }}>
                         {moment(item.date, "MM-DD-YYYY").format(
@@ -548,7 +568,7 @@ const MakeSelections = () => {
                           }
                           style={{ width: "100%" }}
                         >
-                          {thaaliSizes.map((size: any) => (
+                          {getItemAllowedSizes(item).map((size: any) => (
                             <Option key={size} value={size}>
                               <span style={{ color: getThaaliSizeColor(size) }}>
                                 {size}

--- a/src/components/admin/fmb/manage-menus/manage-menus.tsx
+++ b/src/components/admin/fmb/manage-menus/manage-menus.tsx
@@ -149,6 +149,8 @@ const ManageMenus = ({ getMenus, setMenusInAdminComp }: any) => {
             id: itemID,
             name: newValues.name,
             reasonNoThaali: newValues.reasonNoThaali || null,
+            sizeRestrictionEnabled: newValues.sizeRestrictionEnabled || false,
+            maxSize: newValues.sizeRestrictionEnabled ? newValues.maxSize : null,
           })
         } else {
           let index = 0
@@ -163,7 +165,9 @@ const ManageMenus = ({ getMenus, setMenusInAdminComp }: any) => {
                   item.date !== newValues.date.format("MM-DD-YYYY") ||
                   item.nothaali !== newValues.nothaali ||
                   item.name !== newValues.name ||
-                  item.reasonNoThaali !== newValues.reasonNoThaali
+                  item.reasonNoThaali !== newValues.reasonNoThaali ||
+                  (item.sizeRestrictionEnabled || false) !== (newValues.sizeRestrictionEnabled || false) ||
+                  item.maxSize !== newValues.maxSize
                 ) {
                   shouldUpdateInFirebase = true
                   // set new values
@@ -171,6 +175,8 @@ const ManageMenus = ({ getMenus, setMenusInAdminComp }: any) => {
                   item.nothaali = newValues.nothaali
                   item.name = newValues.name
                   item.reasonNoThaali = newValues.reasonNoThaali || null
+                  item.sizeRestrictionEnabled = newValues.sizeRestrictionEnabled || false
+                  item.maxSize = newValues.sizeRestrictionEnabled ? newValues.maxSize : null
                 }
               }
               continue

--- a/src/components/admin/fmb/manage-menus/single-menu.tsx
+++ b/src/components/admin/fmb/manage-menus/single-menu.tsx
@@ -8,7 +8,11 @@ import {
   DatePicker,
   Input,
   Checkbox,
+  Switch,
+  Select,
+  Space,
 } from "antd"
+import { ALL_SIZES } from "../../../../utils/thaali-sizes"
 import { Row, Col, Button } from "react-bootstrap"
 import styled from "styled-components"
 import { shortMonthToLongMonth } from "../../../../functions/calendar"
@@ -202,6 +206,9 @@ const SingleMenu = ({
                             "dddd, MMM Do YYYY"
                           )}
                         </li>
+                        {!item.nothaali && item.sizeRestrictionEnabled && (
+                          <li>Max Size: {item.maxSize}</li>
+                        )}
                       </ul>
                     </Col>
 
@@ -224,6 +231,8 @@ const SingleMenu = ({
                                     date: moment(item.date, "MM-DD-YYYY"),
                                     nothaali: item.nothaali,
                                     reasonNoThaali: item.reasonNoThaali,
+                                    sizeRestrictionEnabled: item.sizeRestrictionEnabled || false,
+                                    maxSize: item.maxSize || null,
                                   })
                                   setCurrentlyEditingMenuItemDetails({
                                     monthName: menu.month,
@@ -251,6 +260,8 @@ const SingleMenu = ({
                                     date: moment(item.date, "MM-DD-YYYY"),
                                     nothaali: item.nothaali,
                                     reasonNoThaali: item.reasonNoThaali,
+                                    sizeRestrictionEnabled: item.sizeRestrictionEnabled || false,
+                                    maxSize: item.maxSize || null,
                                   })
                                   setCurrentlyEditingMenuItemDetails({
                                     monthName: menu.month,
@@ -284,6 +295,8 @@ const SingleMenu = ({
                     date: null,
                     nothaali: null,
                     reasonNoThaali: null,
+                    sizeRestrictionEnabled: false,
+                    maxSize: null,
                   })
                   setCurrentlyEditingMenuItemDetails({
                     monthName: menu.month,
@@ -398,7 +411,7 @@ const SingleMenu = ({
               onChange={(event: any) => {
                 const isNameFieldDisabled = event.target.checked
                 if (isNameFieldDisabled) {
-                  editMenuItemForm.setFieldsValue({ name: "None" })
+                  editMenuItemForm.setFieldsValue({ name: "None", sizeRestrictionEnabled: false, maxSize: null })
                 }
                 setNameFieldDisabled(isNameFieldDisabled)
               }}
@@ -406,6 +419,37 @@ const SingleMenu = ({
               No Thaali
             </Checkbox>
           </Form.Item>
+          {!nameFieldDisabled && (
+            <Form.Item noStyle shouldUpdate={(prev: any, curr: any) => prev.sizeRestrictionEnabled !== curr.sizeRestrictionEnabled}>
+              {() => (
+                <Space style={{ marginTop: "0.5rem" }}>
+                  <Form.Item
+                    name="sizeRestrictionEnabled"
+                    valuePropName="checked"
+                    style={{ marginBottom: 0 }}
+                  >
+                    <Switch size="small" />
+                  </Form.Item>
+                  <span>Limit item size</span>
+                  {editMenuItemForm.getFieldValue("sizeRestrictionEnabled") && (
+                    <Form.Item
+                      name="maxSize"
+                      rules={[{ required: true, message: "Select max size" }]}
+                      style={{ marginBottom: 0 }}
+                    >
+                      <Select style={{ width: 120 }} placeholder="Max size">
+                        {ALL_SIZES.map((size) => (
+                          <Select.Option key={size} value={size}>
+                            {size}
+                          </Select.Option>
+                        ))}
+                      </Select>
+                    </Form.Item>
+                  )}
+                </Space>
+              )}
+            </Form.Item>
+          )}
         </Form>
       </Modal>
       <Modal

--- a/src/components/admin/fmb/manage-menus/single-menu.tsx
+++ b/src/components/admin/fmb/manage-menus/single-menu.tsx
@@ -438,7 +438,7 @@ const SingleMenu = ({
                       style={{ marginBottom: 0 }}
                     >
                       <Select style={{ width: 120 }} placeholder="Max size">
-                        {ALL_SIZES.map((size) => (
+                        {ALL_SIZES.filter((s) => s !== "Grand").map((size) => (
                           <Select.Option key={size} value={size}>
                             {size}
                           </Select.Option>

--- a/src/utils/thaali-sizes.ts
+++ b/src/utils/thaali-sizes.ts
@@ -21,10 +21,3 @@ export const getAllowedSizes = (effectiveMaxSize: string): string[] => {
   const maxRank = SIZE_HIERARCHY[effectiveMaxSize] ?? 4
   return ALL_SIZES.filter((size) => SIZE_HIERARCHY[size] <= maxRank)
 }
-
-export const canSelectSize = (size: string, effectiveMaxSize: string): boolean => {
-  const sizeRank = SIZE_HIERARCHY[size]
-  const maxRank = SIZE_HIERARCHY[effectiveMaxSize]
-  if (sizeRank === undefined || maxRank === undefined) return false
-  return sizeRank <= maxRank
-}

--- a/src/utils/thaali-sizes.ts
+++ b/src/utils/thaali-sizes.ts
@@ -1,0 +1,30 @@
+const SIZE_HIERARCHY: Record<string, number> = {
+  Grand: 4,
+  Full: 3,
+  Half: 2,
+  Quarter: 1,
+}
+
+export const ALL_SIZES = ["Grand", "Full", "Half", "Quarter"] as const
+
+export const getEffectiveMaxSize = (
+  familyMaxSize: string,
+  itemMaxSize?: string | null
+): string => {
+  if (!itemMaxSize) return familyMaxSize
+  const familyRank = SIZE_HIERARCHY[familyMaxSize] ?? 4
+  const itemRank = SIZE_HIERARCHY[itemMaxSize] ?? 4
+  return familyRank <= itemRank ? familyMaxSize : itemMaxSize
+}
+
+export const getAllowedSizes = (effectiveMaxSize: string): string[] => {
+  const maxRank = SIZE_HIERARCHY[effectiveMaxSize] ?? 4
+  return ALL_SIZES.filter((size) => SIZE_HIERARCHY[size] <= maxRank)
+}
+
+export const canSelectSize = (size: string, effectiveMaxSize: string): boolean => {
+  const sizeRank = SIZE_HIERARCHY[size]
+  const maxRank = SIZE_HIERARCHY[effectiveMaxSize]
+  if (sizeRank === undefined || maxRank === undefined) return false
+  return sizeRank <= maxRank
+}


### PR DESCRIPTION
## Summary
- Adds ability for admins to set a max thaali size on individual menu items (e.g., Roti limited to "Half")
- When enabled, the effective max for a user is the more restrictive of their family max and the item max
- New shared utility `thaali-sizes.ts` centralizes size hierarchy logic

## Changes
- **`src/utils/thaali-sizes.ts`** — new utility with `getEffectiveMaxSize()`, `getAllowedSizes()`, `canSelectSize()`
- **Create Menu flow** — inline switch + dropdown per item for "Limit size" / max size, shown in review
- **Manage Menus** — same fields in edit modal + item display shows max size when set
- **Make Selections** — size dropdowns filtered per-item; universal toggle auto-clamps items that exceed their max

## Design decisions
- Both new fields (`sizeRestrictionEnabled`, `maxSize`) are optional — existing menus unaffected, no migration needed
- Admins cannot override item-level restrictions (supply constraint, not preference)
- Universal size toggle auto-clamps: selecting "Full" when an item is capped at "Half" sets that item to "Half"
- Limit size controls sit inline with "No Thaali" checkbox; Delete button wraps to full-width row on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)